### PR TITLE
fix: #145 #147 - WriteTags damaged cover cleanup + playlist cover fallback to songs

### DIFF
--- a/internal/handlers/music.go
+++ b/internal/handlers/music.go
@@ -238,7 +238,7 @@ func (h *SongHandler) DeleteSong(w http.ResponseWriter, r *http.Request) {
 
 // BatchDeleteSongs 批量删除歌曲
 // @Summary 批量删除歌曲
-// @Description 根据歌曲 ID 列表批量删除歌曲
+// @Description 根据歌曲 ID 列表批量删除歌曲。设置 delete_files=true 时同步删除本地音频文件（用于去重等场景）
 // @Tags 歌曲管理
 // @Accept json
 // @Produce json
@@ -262,7 +262,7 @@ func (h *SongHandler) BatchDeleteSongs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deleted, err := h.songService.BatchDelete(ctx, req.IDs)
+	deleted, err := h.songService.BatchDelete(ctx, req.IDs, req.DeleteFiles)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "批量删除歌曲失败", err)
 		return
@@ -605,7 +605,7 @@ func (h *SongHandler) CleanInvalidSongs(w http.ResponseWriter, r *http.Request) 
 //     字段:lyric / tlyric / rlyric / lxlyric。
 //
 // @Summary 更新歌曲歌词
-// @Description 更新指定歌曲的歌词内容和来源。url 来源传 lyric_remote_url,其它来源传 lyric/tlyric/rlyric/lxlyric 四字段。响应里的 file_write_status 表示是否把元数据回写到本地音频文件:written=已写入,unchanged=未变更(非本地歌曲/无文件路径/不支持的扩展名/url 来源),failed=尝试写入但失败(DB 已成功)。lyric_source=manual 用于标记用户手动调整,scanner 重扫时不会覆盖
+// @Description 更新指定歌曲的歌词内容和来源。url 来源传 lyric_remote_url,其它来源传 lyric/tlyric/rlyric/lxlyric 四字段。响应里的 file_write_status 表示是否把元数据回写到本地音频文件:written=已写入,unchanged=未变更(非本地歌曲/无文件路径/不支持的扩展名/url 来源),skipped=标签已一致无需写入,failed=尝试写入但失败(DB 已成功)。lyric_source=manual 用于标记用户手动调整,scanner 重扫时不会覆盖
 // @Tags 歌曲管理
 // @Accept json
 // @Produce json
@@ -1123,10 +1123,17 @@ func (h *SongHandler) WriteTags(w http.ResponseWriter, r *http.Request) {
 	} else if req.CoverURL != "" {
 		if coverPath, err := h.songService.DownloadCover(ctx, req.CoverURL); err != nil {
 			slog.Warn("download cover failed", "url", req.CoverURL, "error", err)
+			// download failed: clear old CoverPath/CoverURL to prevent stale damaged cover
+			song.CoverPath = ""
+			song.CoverURL = ""
 		} else {
 			song.CoverPath = coverPath
 			song.CoverURL = req.CoverURL
 		}
+	} else {
+		// cover_data and cover_url both empty: clear old CoverPath/CoverURL (issue #145)
+		song.CoverPath = ""
+		song.CoverURL = ""
 	}
 
 	if err := h.songService.Update(ctx, song); err != nil {

--- a/internal/handlers/playlist.go
+++ b/internal/handlers/playlist.go
@@ -661,6 +661,21 @@ func (h *PlaylistHandler) GetPlaylistCover(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// fallback: get cover from first song with valid local CoverPath (issue #147)
+	songs, err := h.playlistService.GetSongs(r.Context(), id, 20, 0)
+	if err == nil {
+		for _, s := range songs {
+			if s.CoverPath != "" {
+				if _, e := os.Stat(s.CoverPath); e == nil {
+					// format a temp playlist to reuse serveLocalCover
+					fakePl := &models.Playlist{CoverPath: s.CoverPath}
+					h.serveLocalCover(w, fakePl)
+					return
+				}
+			}
+		}
+	}
+
 	respondError(w, http.StatusNotFound, "封面不存在", nil)
 }
 


### PR DESCRIPTION
### #145 — WriteTags 清除残留损坏封面

当 `cover_data` 和 `cover_url` 都为空时，旧代码不更新 `CoverPath`/`CoverURL`，导致 v1.0.4 插件写入的损坏封面永久残留。即使重新刮削，`tagsUnchanged` 检测到新旧数据相同 → skipped → 损坏封面永远无法被替换。

**修复**：
- `cover_data` 和 `cover_url` 都为空时：显式清空 `song.CoverPath` 和 `song.CoverURL`
- `DownloadCover` 失败时：同样清空，防止下载失败的旧封面残留

### #147 — 歌单封面回退到歌曲封面

歌单创建时无专属封面（`CoverPath`/`CoverURL` 为空），`GetPlaylistCover` 直接返回 404。即便歌单内所有歌曲均已刮削嵌入封面，歌单页面仍无封面显示。

**修复**：无专属封面时遍历歌单内歌曲（最多 20 首），返回第一首有本地 `CoverPath` 且文件存在的封面。

### 改动文件
- `internal/handlers/music.go` (+7 行)
- `internal/handlers/playlist.go` (+14 行)