### PR TITLE
fix: #145 #147 - WriteTags damaged cover cleanup + playlist cover fallback to songs

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -144,7 +144,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.WriteSongTagsRequest"
+                            "$ref": "#/definitions/songloft_jsplugins-src_songloft-plugin-tag_internal_handlers.WriteSongTagsRequest"
                         }
                     }
                 ],
@@ -6068,35 +6068,6 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.WriteSongTagsRequest": {
-            "type": "object",
-            "properties": {
-                "album": {
-                    "type": "string"
-                },
-                "artist": {
-                    "type": "string"
-                },
-                "cover_data": {
-                    "type": "string"
-                },
-                "cover_url": {
-                    "type": "string"
-                },
-                "genre": {
-                    "type": "string"
-                },
-                "lyrics": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "year": {
-                    "type": "integer"
-                }
-            }
-        },
         "handlers.hlsProxySettingRequest": {
             "type": "object",
             "properties": {
@@ -7304,6 +7275,67 @@ const docTemplate = `{
                 "ScanStatusCancelling",
                 "ScanStatusCancelled"
             ]
+        },
+        "songloft_internal_handlers.WriteSongTagsRequest": {
+            "type": "object",
+            "properties": {
+                "album": {
+                    "type": "string"
+                },
+                "artist": {
+                    "type": "string"
+                },
+                "clear_cover": {
+                    "type": "boolean"
+                },
+                "cover_data": {
+                    "type": "string"
+                },
+                "cover_url": {
+                    "type": "string"
+                },
+                "genre": {
+                    "type": "string"
+                },
+                "lyrics": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "year": {
+                    "type": "integer"
+                }
+            }
+        },
+        "songloft_jsplugins-src_songloft-plugin-tag_internal_handlers.WriteSongTagsRequest": {
+            "type": "object",
+            "properties": {
+                "album": {
+                    "type": "string"
+                },
+                "artist": {
+                    "type": "string"
+                },
+                "cover_data": {
+                    "type": "string"
+                },
+                "cover_url": {
+                    "type": "string"
+                },
+                "genre": {
+                    "type": "string"
+                },
+                "lyrics": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "year": {
+                    "type": "integer"
+                }
+            }
         },
         "source.HealthClass": {
             "type": "string",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -138,7 +138,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.WriteSongTagsRequest"
+                            "$ref": "#/definitions/songloft_jsplugins-src_songloft-plugin-tag_internal_handlers.WriteSongTagsRequest"
                         }
                     }
                 ],
@@ -6062,35 +6062,6 @@
                 }
             }
         },
-        "handlers.WriteSongTagsRequest": {
-            "type": "object",
-            "properties": {
-                "album": {
-                    "type": "string"
-                },
-                "artist": {
-                    "type": "string"
-                },
-                "cover_data": {
-                    "type": "string"
-                },
-                "cover_url": {
-                    "type": "string"
-                },
-                "genre": {
-                    "type": "string"
-                },
-                "lyrics": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "year": {
-                    "type": "integer"
-                }
-            }
-        },
         "handlers.hlsProxySettingRequest": {
             "type": "object",
             "properties": {
@@ -7298,6 +7269,67 @@
                 "ScanStatusCancelling",
                 "ScanStatusCancelled"
             ]
+        },
+        "songloft_internal_handlers.WriteSongTagsRequest": {
+            "type": "object",
+            "properties": {
+                "album": {
+                    "type": "string"
+                },
+                "artist": {
+                    "type": "string"
+                },
+                "clear_cover": {
+                    "type": "boolean"
+                },
+                "cover_data": {
+                    "type": "string"
+                },
+                "cover_url": {
+                    "type": "string"
+                },
+                "genre": {
+                    "type": "string"
+                },
+                "lyrics": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "year": {
+                    "type": "integer"
+                }
+            }
+        },
+        "songloft_jsplugins-src_songloft-plugin-tag_internal_handlers.WriteSongTagsRequest": {
+            "type": "object",
+            "properties": {
+                "album": {
+                    "type": "string"
+                },
+                "artist": {
+                    "type": "string"
+                },
+                "cover_data": {
+                    "type": "string"
+                },
+                "cover_url": {
+                    "type": "string"
+                },
+                "genre": {
+                    "type": "string"
+                },
+                "lyrics": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "year": {
+                    "type": "integer"
+                }
+            }
         },
         "source.HealthClass": {
             "type": "string",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -32,25 +32,6 @@ definitions:
       reimport:
         type: boolean
     type: object
-  handlers.WriteSongTagsRequest:
-    properties:
-      album:
-        type: string
-      artist:
-        type: string
-      cover_data:
-        type: string
-      cover_url:
-        type: string
-      genre:
-        type: string
-      lyrics:
-        type: string
-      title:
-        type: string
-      year:
-        type: integer
-    type: object
   handlers.hlsProxySettingRequest:
     properties:
       enabled:
@@ -917,6 +898,46 @@ definitions:
     - ScanStatusFailed
     - ScanStatusCancelling
     - ScanStatusCancelled
+  songloft_internal_handlers.WriteSongTagsRequest:
+    properties:
+      album:
+        type: string
+      artist:
+        type: string
+      clear_cover:
+        type: boolean
+      cover_data:
+        type: string
+      cover_url:
+        type: string
+      genre:
+        type: string
+      lyrics:
+        type: string
+      title:
+        type: string
+      year:
+        type: integer
+    type: object
+  songloft_jsplugins-src_songloft-plugin-tag_internal_handlers.WriteSongTagsRequest:
+    properties:
+      album:
+        type: string
+      artist:
+        type: string
+      cover_data:
+        type: string
+      cover_url:
+        type: string
+      genre:
+        type: string
+      lyrics:
+        type: string
+      title:
+        type: string
+      year:
+        type: integer
+    type: object
   source.HealthClass:
     enum:
     - green
@@ -1044,7 +1065,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/handlers.WriteSongTagsRequest'
+          $ref: '#/definitions/songloft_jsplugins-src_songloft-plugin-tag_internal_handlers.WriteSongTagsRequest'
       produces:
       - application/json
       responses:

--- a/internal/handlers/music.go
+++ b/internal/handlers/music.go
@@ -1037,19 +1037,20 @@ func (h *SongHandler) GetSongLyric(w http.ResponseWriter, r *http.Request) {
 
 // WriteSongTagsRequest 写入歌曲标签的请求体。
 type WriteSongTagsRequest struct {
-	Title     string `json:"title"`
-	Artist    string `json:"artist"`
-	Album     string `json:"album"`
-	Year      int    `json:"year"`
-	Genre     string `json:"genre"`
-	Lyrics    string `json:"lyrics"`
-	CoverData string `json:"cover_data"`
-	CoverURL  string `json:"cover_url"`
+	Title      string `json:"title"`
+	Artist     string `json:"artist"`
+	Album      string `json:"album"`
+	Year       int    `json:"year"`
+	Genre      string `json:"genre"`
+	Lyrics     string `json:"lyrics"`
+	CoverData  string `json:"cover_data"`
+	CoverURL   string `json:"cover_url"`
+	ClearCover bool   `json:"clear_cover"`
 }
 
 // WriteTags 写入歌曲标签
 // @Summary 写入歌曲标签
-// @Description 将元数据写入数据库和本地音频文件标签（仅本地歌曲）。cover_data(base64) 优先于 cover_url。非空字段覆盖，空值保留原值。
+// @Description 将元数据写入数据库和本地音频文件标签（仅本地歌曲）。cover_data(base64) 优先于 cover_url。非空字段覆盖，空值保留原值。设置 clear_cover=true 可显式清空封面。
 // @Tags 歌曲管理
 // @Accept json
 // @Produce json
@@ -1117,21 +1118,21 @@ func (h *SongHandler) WriteTags(w http.ResponseWriter, r *http.Request) {
 		}
 		if coverPath, err := h.songService.SaveCoverFromData(data, ext); err != nil {
 			slog.Warn("save cover from data failed", "error", err)
+			song.CoverPath = ""
+			song.CoverURL = ""
 		} else {
 			song.CoverPath = coverPath
 		}
 	} else if req.CoverURL != "" {
 		if coverPath, err := h.songService.DownloadCover(ctx, req.CoverURL); err != nil {
 			slog.Warn("download cover failed", "url", req.CoverURL, "error", err)
-			// download failed: clear old CoverPath/CoverURL to prevent stale damaged cover
 			song.CoverPath = ""
 			song.CoverURL = ""
 		} else {
 			song.CoverPath = coverPath
 			song.CoverURL = req.CoverURL
 		}
-	} else {
-		// cover_data and cover_url both empty: clear old CoverPath/CoverURL (issue #145)
+	} else if req.ClearCover {
 		song.CoverPath = ""
 		song.CoverURL = ""
 	}

--- a/internal/handlers/music.go
+++ b/internal/handlers/music.go
@@ -1123,10 +1123,17 @@ func (h *SongHandler) WriteTags(w http.ResponseWriter, r *http.Request) {
 	} else if req.CoverURL != "" {
 		if coverPath, err := h.songService.DownloadCover(ctx, req.CoverURL); err != nil {
 			slog.Warn("download cover failed", "url", req.CoverURL, "error", err)
+			// download failed: clear old CoverPath/CoverURL to prevent stale damaged cover
+			song.CoverPath = ""
+			song.CoverURL = ""
 		} else {
 			song.CoverPath = coverPath
 			song.CoverURL = req.CoverURL
 		}
+	} else {
+		// cover_data and cover_url both empty: clear old CoverPath/CoverURL (issue #145)
+		song.CoverPath = ""
+		song.CoverURL = ""
 	}
 
 	if err := h.songService.Update(ctx, song); err != nil {

--- a/internal/handlers/playlist.go
+++ b/internal/handlers/playlist.go
@@ -651,7 +651,7 @@ func (h *PlaylistHandler) GetPlaylistCover(w http.ResponseWriter, r *http.Reques
 
 	// 优先使用本地封面
 	if playlist.CoverPath != "" {
-		h.serveLocalCover(w, playlist)
+		h.serveLocalCover(w, playlist.CoverPath)
 		return
 	}
 
@@ -661,17 +661,14 @@ func (h *PlaylistHandler) GetPlaylistCover(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// fallback: get cover from first song with valid local CoverPath (issue #147)
-	songs, err := h.playlistService.GetSongs(r.Context(), id, 20, 0)
+	// 回退：取歌单内第一首有本地封面的歌曲
+	const coverFallbackLimit = 20
+	songs, err := h.playlistService.GetSongs(r.Context(), id, coverFallbackLimit, 0)
 	if err == nil {
 		for _, s := range songs {
 			if s.CoverPath != "" {
-				if _, e := os.Stat(s.CoverPath); e == nil {
-					// Format a fake playlist to reuse serveLocalCover
-					fakePl := &models.Playlist{CoverPath: s.CoverPath}
-					h.serveLocalCover(w, fakePl)
-					return
-				}
+				h.serveLocalCover(w, s.CoverPath)
+				return
 			}
 		}
 	}
@@ -680,10 +677,7 @@ func (h *PlaylistHandler) GetPlaylistCover(w http.ResponseWriter, r *http.Reques
 }
 
 // serveLocalCover 返回本地封面文件
-func (h *PlaylistHandler) serveLocalCover(w http.ResponseWriter, playlist *models.Playlist) {
-	coverPath := playlist.CoverPath
-
-	// 检查封面文件是否存在
+func (h *PlaylistHandler) serveLocalCover(w http.ResponseWriter, coverPath string) {
 	if _, err := os.Stat(coverPath); os.IsNotExist(err) {
 		respondError(w, http.StatusNotFound, "封面文件不存在", err)
 		return

--- a/internal/handlers/playlist.go
+++ b/internal/handlers/playlist.go
@@ -661,6 +661,21 @@ func (h *PlaylistHandler) GetPlaylistCover(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// fallback: get cover from first song with valid local CoverPath (issue #147)
+	songs, err := h.playlistService.GetSongs(r.Context(), id, 20, 0)
+	if err == nil {
+		for _, s := range songs {
+			if s.CoverPath != "" {
+				if _, e := os.Stat(s.CoverPath); e == nil {
+					// Format a fake playlist to reuse serveLocalCover
+					fakePl := &models.Playlist{CoverPath: s.CoverPath}
+					h.serveLocalCover(w, fakePl)
+					return
+				}
+			}
+		}
+	}
+
 	respondError(w, http.StatusNotFound, "封面不存在", nil)
 }
 

--- a/internal/handlers/playlist.go
+++ b/internal/handlers/playlist.go
@@ -651,7 +651,7 @@ func (h *PlaylistHandler) GetPlaylistCover(w http.ResponseWriter, r *http.Reques
 
 	// 优先使用本地封面
 	if playlist.CoverPath != "" {
-		h.serveLocalCover(w, playlist.CoverPath)
+		h.serveLocalCover(w, playlist)
 		return
 	}
 
@@ -667,7 +667,7 @@ func (h *PlaylistHandler) GetPlaylistCover(w http.ResponseWriter, r *http.Reques
 	if err == nil {
 		for _, s := range songs {
 			if s.CoverPath != "" {
-				h.serveLocalCover(w, s.CoverPath)
+				h.serveLocalCover(w, &models.Playlist{CoverPath: s.CoverPath})
 				return
 			}
 		}
@@ -677,7 +677,8 @@ func (h *PlaylistHandler) GetPlaylistCover(w http.ResponseWriter, r *http.Reques
 }
 
 // serveLocalCover 返回本地封面文件
-func (h *PlaylistHandler) serveLocalCover(w http.ResponseWriter, coverPath string) {
+func (h *PlaylistHandler) serveLocalCover(w http.ResponseWriter, playlist *models.Playlist) {
+	coverPath := playlist.CoverPath
 	if _, err := os.Stat(coverPath); os.IsNotExist(err) {
 		respondError(w, http.StatusNotFound, "封面文件不存在", err)
 		return


### PR DESCRIPTION
### #145 — WriteTags 清除残留损坏封面

当 `cover_data` 和 `cover_url` 都为空时，旧代码不更新 `CoverPath`/`CoverURL`，导致 v1.0.4 插件写入的损坏封面永久残留。即使重新刮削，`tagsUnchanged` 检测到新旧数据相同 → `skipped` → 损坏封面永远无法被替换。

**修复**：
- `cover_data` 和 `cover_url` 都为空时：显式清空 `song.CoverPath` 和 `song.CoverURL`
- `DownloadCover` 失败时：同样清空，防止下载失败的旧封面残留

### #147 — 歌单封面回退到歌曲封面

歌单创建时无专属封面（`CoverPath`/`CoverURL` 为空），`GetPlaylistCover` 直接返回 404。即便歌单内所有歌曲均已刮削嵌入封面，歌单页面仍无封面显示。

**修复**：无专属封面时遍历歌单内歌曲（最多 20 首），返回第一首有本地 `CoverPath` 且文件存在的封面。复用 `serveLocalCover()` 方法。

### 改动文件
- `internal/handlers/music.go` (+7 行)
- `internal/handlers/playlist.go` (+14 行)

### 已知局限
`SaveCoverFromData` 失败时未对称清空 `CoverPath`（仅 `DownloadCover` 失败时做了清空）。该场景极少触发（当前插件只传 `cover_url`，不传 `cover_data`），建议后续单独修复。