### PR TITLE
fix(fingerprint): remove invalid length threshold in ExtractFingerprint

### DIFF
--- a/internal/services/fingerprint.go
+++ b/internal/services/fingerprint.go
@@ -74,9 +74,6 @@ func ExtractFingerprint(ctx context.Context, filePath string) (string, float64, 
 	if fingerprint == "" {
 		return "", 0, fmt.Errorf("ffmpeg chromaprint returned empty fingerprint")
 	}
-	if len(fingerprint) > 2000 {
-		return "", 0, fmt.Errorf("fingerprint too long (%d chars), likely corrupted", len(fingerprint))
-	}
 
 	duration := parseDurationFromStderr(stderr.String())
 	return fingerprint, duration, nil


### PR DESCRIPTION
## 问题

ExtractFingerprint 函数中 len(fingerprint) > 2000 的长度检查过于严格。Chromaprint 指纹长度与歌曲时长成正比（约 30 字符/秒），4分钟歌曲的指纹约 8000-9000 字符，全部被错误拒绝。

这导致所有指纹计算失败，AcoustID 声纹匹配功能完全不可用。

## 修复

移除 len(fingerprint) > 2000 检查。

## 验证

修复后，475 首歌曲指纹全部计算成功（0 失败），AcoustID 查询返回 score 0.98，专辑名和歌词均正确匹配。