### PR TITLE
feat(jsruntime): add AES decrypt bridge

### DIFF
--- a/internal/jsruntime/README.md
+++ b/internal/jsruntime/README.md
@@ -196,7 +196,8 @@ JS 运行时通过以下 Go 桥接函数提供系统级功能：
 - `__go_console(level, msg)`: 控制台日志输出
 - `__go_fetch_async(url, method, headers, body) -> id`: 真异步 HTTP 请求；
   返回 id，结果通过 asyncResults 通道回投，由事件循环 resolve 对应 Promise
-  （插件代码统一通过 `globalThis.fetch()` 调用，封装好 Promise 包装）
+  （插件代码统一通过 `globalThis.fetch()` 调用，封装好 Promise 包装）；
+  支持内部请求头 `X-Fetch-Timeout-Ms` 设置单次请求超时（100-30000ms，默认 30000ms，不转发给目标服务器）
 - `__go_bridge(action, data) -> id`: 真异步桥接调用（storage/songs/playlists/comm/jsenv）
 - `__go_pop_async_result() -> json|""`: 主事件循环排空异步结果队列的非阻塞接口
 - `__go_now_ms()`: 当前时间戳（毫秒）
@@ -205,6 +206,7 @@ JS 运行时通过以下 Go 桥接函数提供系统级功能：
 - `__go_crypto_md5(str)`: MD5 哈希
 - `__go_crypto_random_bytes(size)`: 生成随机字节
 - `__go_crypto_aes_encrypt(data, mode, key, iv)`: AES 加密
+- `__go_crypto_aes_decrypt(data, mode, key, iv)`: AES 解密
 - `__go_crypto_rsa_encrypt(data, keyPEM)`: RSA 加密
 - `__go_zlib_inflate(data)`: zlib 解压
 - `__go_zlib_deflate(data)`: zlib 压缩

--- a/internal/jsruntime/crypto_native_test.go
+++ b/internal/jsruntime/crypto_native_test.go
@@ -92,6 +92,38 @@ func TestNativeRC4(t *testing.T) {
 	}
 }
 
+// TestNativeAESDecrypt 验证 AES 解密桥接与现有 AES 加密桥接对称可用。
+func TestNativeAESDecrypt(t *testing.T) {
+	m := NewJSEnvManager()
+	defer m.SignalShutdown()
+	envID := "test-aes-decrypt"
+	if err := m.CreateEnv(envID, polyfillJS, 1); err != nil {
+		t.Fatalf("CreateEnv: %v", err)
+	}
+	defer m.DestroyEnv(envID)
+
+	code := `
+		var data = __go_buffer_from("hello aes decrypt", "utf8");
+		var key = __go_buffer_from("1234567890abcdef", "utf8");
+		var iv = __go_buffer_from("abcdef1234567890", "utf8");
+		var cbc = __go_crypto_aes_encrypt(data, "cbc", key, iv);
+		var ecb = __go_crypto_aes_encrypt(data, "ecb", key, "");
+		[
+			__go_buffer_to_string(__go_crypto_aes_decrypt(cbc, "cbc", key, iv), "utf8"),
+			__go_buffer_to_string(__go_crypto_aes_decrypt(ecb, "ecb", key, ""), "utf8"),
+			crypto.aesDecrypt(crypto.aesEncrypt("hello aes decrypt", "ecb", "1234567890abcdef"), "ecb", "1234567890abcdef").toString("utf8")
+		].join("|")
+	`
+	res, err := m.ExecuteJS(context.Background(), envID, code, 1000)
+	if err != nil {
+		t.Fatalf("ExecuteJS: %v", err)
+	}
+	want := "hello aes decrypt|hello aes decrypt|hello aes decrypt"
+	if res.Result != want {
+		t.Errorf("aes decrypt roundtrip = %q, want %q", res.Result, want)
+	}
+}
+
 // TestNativeCryptoWrapper 验证 globalThis.crypto.sha256Bytes / rc4 包装可用。
 func TestNativeCryptoWrapper(t *testing.T) {
 	m := NewJSEnvManager()

--- a/internal/jsruntime/polyfill.go
+++ b/internal/jsruntime/polyfill.go
@@ -37,7 +37,7 @@ globalThis.console = {
     var bridgeNames = ['__go_send', '__go_console', '__go_fetch_async', '__go_now_ms',
         '__go_buffer_from', '__go_buffer_to_string', '__go_crypto_md5', '__go_crypto_sha256',
         '__go_crypto_sha1', '__go_crypto_sha256_bytes', '__go_crypto_rc4',
-        '__go_crypto_random_bytes', '__go_crypto_aes_encrypt', '__go_crypto_rsa_encrypt',
+        '__go_crypto_random_bytes', '__go_crypto_aes_encrypt', '__go_crypto_aes_decrypt', '__go_crypto_rsa_encrypt',
         '__go_zlib_inflate', '__go_zlib_deflate', '__go_raw_inflate',
         '__go_pop_async_result',
         '__go_ws_connect_async', '__go_ws_send', '__go_ws_close', '__go_ws_state'];
@@ -475,6 +475,13 @@ globalThis.crypto = {
         var ivHex = (iv && iv._hex) ? iv._hex : (iv ? __go_buffer_from(String(iv), 'utf8') : '');
         return { _hex: __go_crypto_aes_encrypt(dataHex, mode || 'cbc', keyHex, ivHex),
                  toString: function(fmt) { return __go_buffer_to_string(this._hex, fmt || 'base64'); } };
+    },
+    aesDecrypt: function(buffer, mode, key, iv) {
+        var dataHex = (buffer && buffer._hex) ? buffer._hex : __go_buffer_from(String(buffer), 'base64');
+        var keyHex = (key && key._hex) ? key._hex : __go_buffer_from(String(key), 'utf8');
+        var ivHex = (iv && iv._hex) ? iv._hex : (iv ? __go_buffer_from(String(iv), 'utf8') : '');
+        return { _hex: __go_crypto_aes_decrypt(dataHex, mode || 'cbc', keyHex, ivHex),
+                 toString: function(fmt) { return __go_buffer_to_string(this._hex, fmt || 'utf8'); } };
     },
     rsaEncrypt: function(buffer, key) {
         var dataHex = (buffer && buffer._hex) ? buffer._hex : __go_buffer_from(String(buffer), 'utf8');

--- a/internal/jsruntime/runtime.go
+++ b/internal/jsruntime/runtime.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1582,6 +1583,11 @@ func registerBridgeFunctions(vm *quickjs.VM, env *JSEnv) error {
 		return fmt.Errorf("register __go_crypto_aes_encrypt: %w", err)
 	}
 
+	// __go_crypto_aes_decrypt(dataHex, mode, keyHex, ivHex) — AES 解密
+	if err := vm.RegisterFunc("__go_crypto_aes_decrypt", goCryptoAesDecrypt, false); err != nil {
+		return fmt.Errorf("register __go_crypto_aes_decrypt: %w", err)
+	}
+
 	// __go_crypto_rsa_encrypt(dataHex, keyPEM) — RSA 公钥加密
 	if err := vm.RegisterFunc("__go_crypto_rsa_encrypt", goCryptoRsaEncrypt, false); err != nil {
 		return fmt.Errorf("register __go_crypto_rsa_encrypt: %w", err)
@@ -1850,10 +1856,37 @@ func registerBridgeFunctions(vm *quickjs.VM, env *JSEnv) error {
 //
 // 支持 X-Fetch-No-Redirect 请求头：存在时不自动跟随重定向，让 JS 侧处理
 // 重定向链（如 xiaomi 登录流程的 Cookie 收集）。
+// 支持 X-Fetch-Timeout-Ms 请求头：设置单次请求超时（100-30000ms），该内部头不会转发。
 func doHTTPRequest(url, method, headersJSON, bodyHex string) string {
 	slog.Debug("doHTTPRequest", "url", url, "method", method, "headers", headersJSON)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// 解析并设置请求头
+	var headers map[string]string
+	noRedirect := false
+	timeout := 30 * time.Second
+	if headersJSON != "" && headersJSON != "{}" {
+		if jsonErr := json.Unmarshal([]byte(headersJSON), &headers); jsonErr == nil {
+			for k, v := range headers {
+				if strings.EqualFold(k, "X-Fetch-No-Redirect") {
+					noRedirect = true
+					continue // 不传递此内部控制头
+				}
+				if strings.EqualFold(k, "X-Fetch-Timeout-Ms") {
+					if ms, parseErr := strconv.Atoi(strings.TrimSpace(v)); parseErr == nil && ms > 0 {
+						if ms < 100 {
+							ms = 100
+						} else if ms > 30000 {
+							ms = 30000
+						}
+						timeout = time.Duration(ms) * time.Millisecond
+					}
+					continue
+				}
+			}
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	var reqBody io.Reader
@@ -1870,18 +1903,12 @@ func doHTTPRequest(url, method, headersJSON, bodyHex string) string {
 		return marshalFetchError(err.Error())
 	}
 
-	// 解析并设置请求头
-	var headers map[string]string
-	noRedirect := false
-	if headersJSON != "" && headersJSON != "{}" {
-		if jsonErr := json.Unmarshal([]byte(headersJSON), &headers); jsonErr == nil {
-			for k, v := range headers {
-				if strings.EqualFold(k, "X-Fetch-No-Redirect") {
-					noRedirect = true
-					continue // 不传递此内部控制头
-				}
-				req.Header.Set(k, v)
+	if headers != nil {
+		for k, v := range headers {
+			if strings.EqualFold(k, "X-Fetch-No-Redirect") || strings.EqualFold(k, "X-Fetch-Timeout-Ms") {
+				continue
 			}
+			req.Header.Set(k, v)
 		}
 	}
 
@@ -1893,7 +1920,7 @@ func doHTTPRequest(url, method, headersJSON, bodyHex string) string {
 	httputil.ApplyBasicAuthFromURL(req)
 	url = req.URL.String()
 
-	// 诊断日志：记录实际发送的请求头（X-Fetch-No-Redirect 已剥离，默认头已补充）
+	// 诊断日志：记录实际发送的请求头（内部控制头已剥离，默认头已补充）
 	// header map 构造仅在 Debug 级别时进行，避免热路径无谓分配。
 	if slog.Default().Enabled(ctx, slog.LevelDebug) {
 		actualHeaders := make(map[string]string, len(req.Header))
@@ -1902,7 +1929,7 @@ func doHTTPRequest(url, method, headersJSON, bodyHex string) string {
 				actualHeaders[k] = vals[0]
 			}
 		}
-		slog.Debug("doHTTPRequest actual request headers", "url", url, "noRedirect", noRedirect, "headers", actualHeaders)
+		slog.Debug("doHTTPRequest actual request headers", "url", url, "noRedirect", noRedirect, "timeout", timeout, "headers", actualHeaders)
 	}
 
 	// 根据是否需要跟随重定向选择客户端
@@ -2091,6 +2118,71 @@ func goCryptoAesEncrypt(dataHex, mode, keyHex, ivHex string) string {
 	}
 
 	return hex.EncodeToString(encrypted)
+}
+
+// goCryptoAesDecrypt AES 解密
+// 注意：返回值必须是 string（不能是 (string, error)），
+// 因为 QuickJS 的 RegisterFunc 会将多返回值包装为数组 [value, error]。
+func goCryptoAesDecrypt(dataHex, mode, keyHex, ivHex string) string {
+	data, err := hex.DecodeString(dataHex)
+	if err != nil {
+		slog.Error("goCryptoAesDecrypt data hex decode error", "error", err)
+		return ""
+	}
+	key, err := hex.DecodeString(keyHex)
+	if err != nil {
+		slog.Error("goCryptoAesDecrypt key hex decode error", "error", err)
+		return ""
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		slog.Error("goCryptoAesDecrypt aes new cipher error", "error", err)
+		return ""
+	}
+
+	blockSize := block.BlockSize()
+	if len(data) == 0 || len(data)%blockSize != 0 {
+		slog.Error("goCryptoAesDecrypt invalid data length", "dataLen", len(data), "blockSize", blockSize)
+		return ""
+	}
+
+	decrypted := make([]byte, len(data))
+	switch strings.ToLower(mode) {
+	case "cbc":
+		iv, err := hex.DecodeString(ivHex)
+		if err != nil {
+			slog.Error("goCryptoAesDecrypt iv hex decode error", "error", err)
+			return ""
+		}
+		if len(iv) != blockSize {
+			slog.Error("goCryptoAesDecrypt invalid iv length", "ivLen", len(iv), "blockSize", blockSize)
+			return ""
+		}
+		cbc := cipher.NewCBCDecrypter(block, iv)
+		cbc.CryptBlocks(decrypted, data)
+	case "ecb":
+		for i := 0; i < len(data); i += blockSize {
+			block.Decrypt(decrypted[i:i+blockSize], data[i:i+blockSize])
+		}
+	default:
+		slog.Error("goCryptoAesDecrypt unsupported mode", "mode", mode)
+		return ""
+	}
+
+	padding := int(decrypted[len(decrypted)-1])
+	if padding <= 0 || padding > blockSize || padding > len(decrypted) {
+		slog.Error("goCryptoAesDecrypt invalid pkcs7 padding", "padding", padding, "dataLen", len(decrypted))
+		return ""
+	}
+	for i := len(decrypted) - padding; i < len(decrypted); i++ {
+		if int(decrypted[i]) != padding {
+			slog.Error("goCryptoAesDecrypt invalid pkcs7 padding content")
+			return ""
+		}
+	}
+
+	return hex.EncodeToString(decrypted[:len(decrypted)-padding])
 }
 
 // goCryptoRsaEncrypt RSA 公钥加密


### PR DESCRIPTION
Adds a native AES decrypt bridge to the JS plugin runtime, matching the existing AES encrypt bridge.

Changes:
- register `__go_crypto_aes_decrypt(dataHex, mode, keyHex, ivHex)`
- expose `crypto.aesDecrypt(buffer, mode, key, iv)` in the JS polyfill
- support CBC and ECB modes with PKCS7 unpadding
- strip and consume `X-Fetch-Timeout-Ms` as an internal fetch timeout header
- document the new runtime APIs
- add jsruntime coverage for AES decrypt roundtrips

Why:
Some JS plugins need to decode AES-encrypted third-party responses inside the runtime. Native decrypt avoids slow pure-JS decryption for larger payloads and keeps plugin requests responsive.

Test:
- `go test ./internal/jsruntime`