### PR TITLE
fix(playlist): 歌单封面 URL 补版本号，修复替换封面后不刷新

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -271,6 +271,11 @@ func (s *Song) IsRadio() bool {
 // CoverURLPath 返回客户端用的统一封面 URL。
 // 有封面(本地或远程)时返回 /api/v1/playlists/{id}/cover 端点,后端自动判断本地/远程
 // 无封面时返回空字符串,避免客户端发起注定 404 的请求
+//
+// URL 携带 ?v=UpdatedAt 版本号:歌单封面端点缓存头是长 max-age,而 URL 按 ID 固定,
+// 用户替换封面后若 URL 不变,浏览器会一直用旧缓存(表现为封面上传后普通刷新/页面内
+// 导航仍显示旧图)。上传封面走 PlaylistService.UploadCover → Update,必然刷新
+// updated_at,故 ?v= 会随之变化,天然穿透缓存。与歌曲封面 Song.CoverURLPath 一致。
 func (p *Playlist) CoverURLPath() string {
 	if p.ID == 0 {
 		return ""
@@ -278,7 +283,7 @@ func (p *Playlist) CoverURLPath() string {
 	if p.CoverPath == "" && p.CoverURL == "" {
 		return ""
 	}
-	return fmt.Sprintf("/api/v1/playlists/%d/cover", p.ID)
+	return fmt.Sprintf("/api/v1/playlists/%d/cover?v=%d", p.ID, p.UpdatedAt.Unix())
 }
 
 // MarshalJSON 序列化时把 CoverURL 字段统一覆盖为服务端端点。


### PR DESCRIPTION
## 问题

上传/替换歌单封面后，普通刷新或页面内导航仍显示旧封面，只有强制刷新（清缓存）才更新。首页自动创建的「歌手」歌单封面尤其明显。

## 原因

`Playlist.CoverURLPath()` 生成的封面 URL 是按 ID 固定的：

    /api/v1/playlists/{id}/cover

该端点响应头是长 max-age 缓存，而 URL 不带任何版本标识。用户替换封面文件后 URL 不变，浏览器持续命中旧缓存。

对比之下，歌曲封面 `Song.CoverURLPath()` 早已用 `?v={UpdatedAt.Unix()}` 解决了同样的问题，歌单这里遗漏了。

## 修改

给歌单封面 URL 补上版本号，与歌曲封面保持一致：

    /api/v1/playlists/{id}/cover?v={UpdatedAt.Unix()}


## 测试

在自建 ARM64 部署上用打了此补丁的镜像验证：上传歌单封面后，`/api/v1/playlists` 返回的 `cover_url` 变为带 `?v=` 版本号的形式，替换封面后普通刷新即可看到新图。