### PR TITLE
添加主流路由器插件的readme说明

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -197,6 +197,12 @@ In addition to the Flutter client, Songloft also provides an official **Kodi plu
 🔗 **GitHub repository**: [songloft-org/plugin.audio.songloft](https://github.com/songloft-org/plugin.audio.songloft)
 📥 **Download**: [GitHub Releases](https://github.com/songloft-org/plugin.audio.songloft/releases/latest)
 
+### 📡 Router / ONT Deployment
+
+Routers and ONTs (optical network terminals) are common home network devices that naturally run 24/7, making them ideal hosts for Songloft. The community project **songloft-for-router** provides plugin installation packages for three major router firmware ecosystems — OpenWrt, Entware, and Merlin (including SWRTdev / Koolshare software centers) — helping you easily manage Songloft on your router or ONT.
+
+🔗 **GitHub repository**: [songloft-org/songloft-for-router](https://github.com/songloft-org/songloft-for-router)
+
 ## 🚀 Quick Start
 
 > 🔐 **Security notice (must read)**: The default admin account is `admin / admin`, which is **suitable for local testing only**. For any deployment exposed to the internet or accessed by multiple devices, be sure to set a strong password via the `ADMIN_USERNAME` / `ADMIN_PASSWORD` environment variables before starting; otherwise your music library may be accessible to strangers.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ Songloft 提供三种版本，满足不同使用场景：
 🔗 **GitHub 仓库**：[songloft-org/plugin.audio.songloft](https://github.com/songloft-org/plugin.audio.songloft)
 📥 **下载**：[GitHub Releases](https://github.com/songloft-org/plugin.audio.songloft/releases/latest)
 
+### 📡 路由器 / 光猫部署
+
+路由器与光猫是家庭中常见的基础网络设备，天然支持 24 小时不间断运行，非常适合用于部署 Songloft。社区项目 **songloft-for-router** 提供了面向 OpenWrt、Entware 与梅林（Merlin，含 SWRTdev / Koolshare 软件中心）三类主流路由器固件生态的插件安装包，帮助你在路由器 / 光猫上轻松管理 Songloft 服务。
+
+🔗 **GitHub 仓库**：[songloft-org/songloft-for-router](https://github.com/songloft-org/songloft-for-router)
+
 ## 🚀 快速开始
 
 > 🔐 **安全提示（必读）**：默认管理员账号是 `admin / admin`，**仅适用于本地测试**。任何对外网暴露或多设备访问的部署，请务必通过环境变量 `ADMIN_USERNAME` / `ADMIN_PASSWORD` 设置强密码后再启动；否则你的音乐库可能被陌生人访问。


### PR DESCRIPTION
1. 路由器和光猫家里都有，加上24小时运行，蛮适合部署这个服务的，加了主流路由器的管理插件。
2. 我自己光猫用entware，路由器梅林用梅林插件，测试了没啥问题，运行截图放到https://github.com/songloft-org/songloft-for-router 。openwrt没设备没有测试。
3. 因为没有把二进制打包到插件里面，没法开箱即用，暂时docs/.vitepress/data/downloads.ts没有更新,等完善一点再更新。