### PR TITLE
优化加修bug

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -100,7 +100,20 @@ func (a *App) Close() error {
 	if a.logWriter != nil {
 		_ = a.logWriter.Close()
 	}
-	return nil
+	if a.logWriter != nil {
+		_ = a.logWriter.Close()
+	}
+	return dbErr
+}
+
+// Shutdown 优雅关闭 HTTP 服务器并释放所有资源
+func (a *App) Shutdown(ctx context.Context) error {
+	if a.server != nil {
+		if err := a.server.Shutdown(ctx); err != nil {
+			slog.Warn("HTTP server shutdown error", "error", err)
+		}
+	}
+	return a.Close()
 }
 
 // Shutdown 优雅关闭 HTTP 服务器并释放所有资源

--- a/internal/app/embed.go
+++ b/internal/app/embed.go
@@ -15,7 +15,8 @@ const webEmbedRoot = "songloft-player-build/web-embedded"
 // registerWebStatic 注册 Flutter Web 前端静态文件服务。
 // 精简构建（lite build tag）时 webDist 为空 embed.FS，不挂载根路由，以纯 API 模式运行。
 func (a *App) registerWebStatic() {
-	mime.AddExtensionType(".js", "application/javascript")
+	// 加 charset=utf-8，防止显式覆盖 .js MIME 时丢掉 charset 导致浏览器用默认编码解码 Unicode 字符为乱码。
+	mime.AddExtensionType(".js", "application/javascript; charset=utf-8")
 	mime.AddExtensionType(".css", "text/css; charset=utf-8")
 	mime.AddExtensionType(".svg", "image/svg+xml")
 	mime.AddExtensionType(".woff2", "font/woff2")


### PR DESCRIPTION
修改汇总：

---

### 1. `internal/app/app.go:Close()` — 资源泄漏修复

**原问题：** `db.Close()` 返回 `err` 后直接 `return err`，导致 `logWriter.Close()` 永远不会执行。如果 `db.Close()` 返回了错误（例如 SQLite 关闭时），日志 writer 就漏关了。

**修复：** 把 `db.Close()` 的错误存到变量，同时确保 `logWriter.Close()` 始终执行，最后返回 `dbErr`。

---

### 2. `internal/app/app.go:Start()` — HTTP 服务器缺少超时保护

**原问题：** `http.Server` 没有设置任何 `ReadTimeout`、`ReadHeaderTimeout`、`IdleTimeout`。慢连接攻击可以无限占用 goroutine，一个慢连接发一个字节/秒就能永久维持一个连接。

**修复：** 增加：
- `ReadHeaderTimeout: 10s` — 读请求头超时，防慢连接攻击
- `ReadTimeout: 30s` — 读整个请求体超时，大上传够用
- `IdleTimeout: 120s` — keep-alive 连接复用上限

`WriteTimeout` 不设（0=无限），因为流式音频端点（`/songs/{id}/play`、HLS segment）的传输可能远超任何固定超时，由内部 stall 检测和 ffmpeg 超时自行控制。

---

### 3. `internal/app/app.go:Start()` — 日志格式化优化

**原问题：** `slog.Info(fmt.Sprintf(...))` 先格式化为字符串，再被 slog 重新解析。浪费一次分配。

**修复：** 改为 `slog.Info("HTTP 访问地址", "addr", fmt.Sprintf(...))`，slog 直接处理结构化键值对。保留 `fmt.Sprintf` 因为桌面端 DesktopBackendService 需要解析固定格式的地址串。

---

### 4. `internal/app/compress.go:serve()` — 原始文件 fallback 缺 Content-Type

**原问题：** `precompressedFS` 的 fallback 路径（客户端不支持 br/gzip 编码时读取原始文件）只设置了 `Content-Length`，**没有设置 `Content-Type`**。浏览器收到响应后缺 Content-Type，可能用错误编码解码 JavaScript 文件。

**修复：** 在原始文件 fallback 路径也加上 `w.Header().Set("Content-Type", entry.mimeType)`，确保与预压缩路径的 Content-Type 一致。

---

### 5. `internal/app/app.go` — 修复双逗号语法错误

`1 * time.Hour,,` → `1 * time.Hour`（之前改动遗留的语法错误）。

---
>DeepSeek总结